### PR TITLE
Use the typechecker to resolve import paths

### DIFF
--- a/src/ppx_import.cppo.ml
+++ b/src/ppx_import.cppo.ml
@@ -98,7 +98,14 @@ let rec try_open_module_type env module_type =
   match module_type with
   | Mty_signature sig_items -> Some sig_items
   | Mty_functor _ -> None
-  | (Mty_ident path | Mty_alias (_, path)) ->
+  | (Mty_ident path
+     | Mty_alias
+#if OCAML_VERSION <= (4, 03, 0)
+                 path
+#else
+                 (_, path)
+#endif
+    ) ->
     begin match
         (try Some (Env.find_module path env) with Not_found -> None)
       with


### PR DESCRIPTION
This should fix the issue identified by #23.

The code is a bit complex (see the long documentation comment) because ppx_import supports querying the components of a module type, for example `Map.OrderedType.t`, which makes sense but is not a valid OCaml path.

I made a first much simpler and more naive attempt which does not support those sub-module-type names in paths (in particular, the testsuite does not pass), daf4cd5819f5963f33ae136a1115859f7c806c89.