### PR TITLE
Fix import of signatures with mutually recursive types

### DIFF
--- a/src/ppx_import.ml
+++ b/src/ppx_import.ml
@@ -380,7 +380,9 @@ let type_declaration ~tool_name mapper type_decl =
 
 let rec psig_of_tsig ~subst ?(trec=[]) tsig =
   match tsig with
-  | (Sig_type (_, _, Trec_first) | _) :: _ when trec <> [] ->
+  | _ when trec <> [] && match tsig with
+    | Sig_type (_, _, recflag) :: _ -> recflag = Trec_first
+    | _ -> true ->
     let psig_desc = Psig_type(Recursive, trec) in
     { psig_desc; psig_loc = Location.none } :: psig_of_tsig ~subst tsig
   | Sig_type (id, ttype_decl, rec_flag) :: rest ->

--- a/src_test/stuff.ml
+++ b/src_test/stuff.ml
@@ -20,3 +20,8 @@ module MI = struct
 end
 open MI
 type nonrec i = I of i
+
+module type S_rec = sig
+  type t = A of u
+  and u = B of t
+end

--- a/src_test/test_ppx_import.ml
+++ b/src_test/test_ppx_import.ml
@@ -11,6 +11,7 @@ type 'b g' = [%import: 'b Stuff.g]
 type h = [%import: Stuff.h]
 module MI = Stuff.MI
 type i = [%import: Stuff.i]
+module type S_rec = [%import: (module Stuff.S_rec)]
 
 let test_constr _ctxt =
   ignore ([A1; A2 "a"]);


### PR DESCRIPTION
Import of signatures with mutually recursive types was broken.

If a signature with mutually recursive types was defined in `a.ml`:

```
module type S = sig
  type t = A of u
  and u = B of t
end
```

then the compilation of the following compilation unit `b.ml` fails:

```
module type S = [%import: (module A.S)]
```

The reason is that the following pattern matching branch was broken in
two ways:

```
| (Sig_type (_, _, Trec_first) | _) :: _ when trec <> [] ->
```

1. `_` is a catch all, so it matches in particular `Sig_type` with
`rec_flag` other than `Trec_first`, i.e. the left hand side branch
of pattern disjunction is useless;
 
2. `trec` should be appended to the result in the final case of the
empty list (`tsig = []`).