### PR TITLE
[bug fix] Import module types with optional arguments

### DIFF
--- a/src/ppx_import.ml
+++ b/src/ppx_import.ml
@@ -200,8 +200,16 @@ let rec core_type_of_type_expr ~subst type_expr =
     end
   | Tarrow (label, lhs, rhs, _) ->
     let label = Tt.copy_arg_label label in
-    Typ.arrow label (core_type_of_type_expr ~subst lhs)
-                    (core_type_of_type_expr ~subst rhs)
+    let lhs = core_type_of_type_expr ~subst lhs in
+    let lhs =
+      match label with
+      | Optional _ ->
+          begin match lhs with
+          | [%type: [%t? lhs] option] -> lhs
+          | _ -> assert false
+          end
+      | _ -> lhs in
+    Typ.arrow label lhs (core_type_of_type_expr ~subst rhs)
   | Ttuple xs ->
     Typ.tuple (List.map (core_type_of_type_expr ~subst) xs)
   | Tconstr (path, args, _) ->

--- a/src_test/stuff.ml
+++ b/src_test/stuff.ml
@@ -25,3 +25,7 @@ module type S_rec = sig
   type t = A of u
   and u = B of t
 end
+
+module type S_optional = sig
+  val f : ?opt:int -> unit -> unit
+end

--- a/src_test/test_ppx_import.ml
+++ b/src_test/test_ppx_import.ml
@@ -30,6 +30,13 @@ let test_deriving _ctxt =
   assert_equal ~printer:(fun x -> x)
                "(Stuff.A2 \"a\")" (show_a' (A2 "a"))
 
+module type S_optional = [%import: (module Stuff.S_optional)]
+
+module Test_optional : S_optional = struct
+  let f ?(opt = 0) () =
+    ignore opt
+end
+
 type longident = [%import: Longident.t] [@@deriving show]
 
 type package_type =


### PR DESCRIPTION
When importing a module type containing a function value taking an
optional argument of type `t`, the imported type for the argument was
`t option` instead of `t`.