### PR TITLE
[migrate_parsetree] Qualify migrate-parsetree modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   - OCAML=4.07.1
 
 script:
-  - sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.2/opam-2.0.2-x86_64-linux -o /usr/bin/opam
+  - sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.4/opam-2.0.4-x86_64-linux -o /usr/bin/opam
   - sudo chmod 755 /usr/bin/opam
   - opam init --disable-sandboxing -c $OCAML
   - opam switch set $OCAML

--- a/src/ppx_import.ml
+++ b/src/ppx_import.ml
@@ -1,14 +1,12 @@
 (* Don't mask native Outcometree *)
 module Ot = Outcometree
 
-open Ast_406
 open Ppx_tools_406
-
-open Longident
-open Asttypes
-open Parsetree
-open Ast_mapper
-open Ast_helper
+open Migrate_parsetree.Ast_406.Longident
+open Migrate_parsetree.Ast_406.Asttypes
+open Migrate_parsetree.Ast_406.Parsetree
+open Migrate_parsetree.Ast_406.Ast_mapper
+open Migrate_parsetree.Ast_406.Ast_helper
 open Types
 
 module Tt = Ppx_types_migrate

--- a/src/ppx_types_migrate.ml
+++ b/src/ppx_types_migrate.ml
@@ -2,11 +2,11 @@ module At = Asttypes
 module Pt = Parsetree
 module Ot = Outcometree
 
-module Ab = Ast_406.Asttypes
-module Pb = Ast_406.Parsetree
-module Ob = Ast_406.Outcometree
+module Ab = Migrate_parsetree.Ast_406.Asttypes
+module Pb = Migrate_parsetree.Ast_406.Parsetree
+module Ob = Migrate_parsetree.Ast_406.Outcometree
 
-module IMigrate = Migrate_parsetree.Convert(Migrate_parsetree_versions.OCaml_current)(Migrate_parsetree_versions.OCaml_406)
+module IMigrate = Migrate_parsetree.Convert(Migrate_parsetree.Versions.OCaml_current)(Migrate_parsetree.Versions.OCaml_406)
 
 (* copy_mutable_flag / private_flag / arg_label are not exported by
    OMP so not worth the pain of the hack *)


### PR DESCRIPTION
ocaml-migrate-parsetree has now deprecated unqualified access.