### PR TITLE
[migrate_parsetree] Update to 407 ast and workaround metaquot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   - OCAML=4.07.1
 
 script:
-  - sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.4/opam-2.0.4-x86_64-linux -o /usr/bin/opam
+  - sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.5/opam-2.0.5-x86_64-linux -o /usr/bin/opam
   - sudo chmod 755 /usr/bin/opam
   - opam init --disable-sandboxing -c $OCAML
   - opam switch set $OCAML

--- a/ppx_import.opam
+++ b/ppx_import.opam
@@ -13,10 +13,10 @@ tags: [ "syntax" ]
 
 depends: [
   "ocaml"                   {              >= "4.04.2" & < "4.08.0" }
-  "dune"                    { build &      >= "1.2.0"  }
+  "dune"                    {              >= "1.2.0"  }
   "ppxlib"                  {              >= "0.3.1"  }
-  "ppx_tools_versioned"     {              >= "5.2.1"  }
-  "ocaml-migrate-parsetree" {              >= "1.1.0"  }
+  "ppx_tools_versioned"     {              >= "5.2.2"  }
+  "ocaml-migrate-parsetree" {              >= "1.2.0"  }
   "ounit"                   { with-test                }
   "ppx_deriving"            { with-test  & >= "4.2.1"  }
 ]

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
-  (public_name ppx_import)
-  (kind ppx_rewriter)
-  (preprocess (pps ppx_tools_versioned.metaquot_406))
-  (libraries ppx_tools_versioned
-             ppx_tools_versioned.metaquot_406
-             ocaml-migrate-parsetree))
+ (public_name ppx_import)
+ (kind ppx_rewriter)
+ (preprocess (pps ppx_tools_versioned.metaquot_407))
+ (libraries ppx_tools_versioned
+            ppx_tools_versioned.metaquot_407
+            ocaml-migrate-parsetree))

--- a/src/ppx_import.ml
+++ b/src/ppx_import.ml
@@ -1,12 +1,14 @@
 (* Don't mask native Outcometree *)
 module Ot = Outcometree
 
-open Ppx_tools_406
-open Migrate_parsetree.Ast_406.Longident
-open Migrate_parsetree.Ast_406.Asttypes
-open Migrate_parsetree.Ast_406.Parsetree
-open Migrate_parsetree.Ast_406.Ast_mapper
-open Migrate_parsetree.Ast_406.Ast_helper
+open Ppx_tools_407
+
+open Migrate_parsetree
+open Ast_407.Longident
+open Ast_407.Asttypes
+open Ast_407.Parsetree
+open Ast_407.Ast_mapper
+open Ast_407.Ast_helper
 open Types
 
 module Tt = Ppx_types_migrate
@@ -472,7 +474,7 @@ let () =
   (* Position 0 is the default, ppx_import should run pretty early,
      thus using -10 *)
   Driver.register ~name:"ppx_import" ~args:[] ~position:(-10)
-    Versions.ocaml_406 (fun config _cookies ->
+    Versions.ocaml_407 (fun config _cookies ->
         let tool_name = config.tool_name in
         let type_declaration = type_declaration ~tool_name in
         let module_type = module_type ~tool_name in

--- a/src/ppx_types_migrate.ml
+++ b/src/ppx_types_migrate.ml
@@ -2,11 +2,12 @@ module At = Asttypes
 module Pt = Parsetree
 module Ot = Outcometree
 
-module Ab = Migrate_parsetree.Ast_406.Asttypes
-module Pb = Migrate_parsetree.Ast_406.Parsetree
-module Ob = Migrate_parsetree.Ast_406.Outcometree
+open Migrate_parsetree
+module Ab = Ast_407.Asttypes
+module Pb = Ast_407.Parsetree
+module Ob = Ast_407.Outcometree
 
-module IMigrate = Migrate_parsetree.Convert(Migrate_parsetree.Versions.OCaml_current)(Migrate_parsetree.Versions.OCaml_406)
+module IMigrate = Convert(Versions.OCaml_current)(Versions.OCaml_407)
 
 (* copy_mutable_flag / private_flag / arg_label are not exported by
    OMP so not worth the pain of the hack *)
@@ -29,9 +30,9 @@ let copy_arg_label (l : At.arg_label) : Ab.arg_label =
 (* Here we want to do a hack due to the large type *)
 let copy_attributes (l : Pt.attributes) : Pb.attributes =
   (* Hack *)
-  let td = Pt.({ ptyp_desc = Ptyp_any;
-                 ptyp_loc = Location.none;
-                 ptyp_attributes = l;
+  let td = Pt.({ ptyp_desc = Ptyp_any
+               ; ptyp_loc = Location.none
+               ; ptyp_attributes = l
                } ) in
   let td = IMigrate.copy_core_type td in
   td.ptyp_attributes


### PR DESCRIPTION
`ocaml-migrate-parsetree` has deprecated unqualified access, however
the metaquot ppx generates unqualified references; thus we open the
modules in a different fashion as to avoid this problem and have a
clean dev build.

We also migrate to the latest AST version that we can support without
migration of the `Types` module.

This is the continuation of #38.
