### PR TITLE
Support ocaml 4.08 and 4.09

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 sudo: required
 language: c
 
@@ -9,11 +9,18 @@ env:
   matrix:
   - OCAML=4.04.2
   - OCAML=4.05.0
+  - OCAML=4.06.0
   - OCAML=4.06.1
+  - OCAML=4.07.0
   - OCAML=4.07.1
+  - OCAML=4.08.0
+  - OCAML=4.08.1
+  - OCAML=4.09.0
+# Wait until ocaml-base-compiler.4.09.1 arrives to opam-repository
+#  - OCAML=4.09.1
 
 script:
-  - sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.5/opam-2.0.5-x86_64-linux -o /usr/bin/opam
+  - sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.6/opam-2.0.6-x86_64-linux -o /usr/bin/opam
   - sudo chmod 755 /usr/bin/opam
   - opam init --disable-sandboxing -c $OCAML
   - opam switch set $OCAML

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+1.7
+---
+
+  * OCaml 4.08 and 4.09 support
+    #46
+    (Etienne Millon)
+
 1.6.2
 -----
 

--- a/ppx_import.opam
+++ b/ppx_import.opam
@@ -12,7 +12,7 @@ dev-repo: "git+https://github.com/ocaml-ppx/ppx_import.git"
 tags: [ "syntax" ]
 
 depends: [
-  "ocaml"                   {              >= "4.04.2" & < "4.08.0" }
+  "ocaml"                   {              >= "4.04.2" & < "4.10.0" }
   "dune"                    {              >= "1.2.0"  }
   "ppxlib"                  {              >= "0.3.1"  }
   "ppx_tools_versioned"     {              >= "5.2.2"  }

--- a/src/compat/dune
+++ b/src/compat/dune
@@ -1,0 +1,2 @@
+(executable
+ (name gen))

--- a/src/compat/gen.ml
+++ b/src/compat/gen.ml
@@ -1,0 +1,17 @@
+let include_ path =
+  let ic = open_in path in
+  let size = in_channel_length ic in
+  let s = really_input_string ic size in
+  print_endline s;
+  close_in ic
+
+let () =
+  let version = Scanf.sscanf Sys.ocaml_version "%d.%d" (fun a b -> (a, b)) in
+  if version >= (4, 8) then
+    include_ "compat/types_ge_408.ml"
+  else
+    include_ "compat/types_lt_408.ml";
+  if version >= (4, 9) then
+    include_ "compat/init_path_ge_409.ml"
+  else
+    include_ "compat/init_path_lt_409.ml"

--- a/src/compat/init_path_ge_409.ml
+++ b/src/compat/init_path_ge_409.ml
@@ -1,0 +1,1 @@
+let init_path () = Compmisc.init_path ()

--- a/src/compat/init_path_lt_409.ml
+++ b/src/compat/init_path_lt_409.ml
@@ -1,0 +1,1 @@
+let init_path () = Compmisc.init_path false

--- a/src/compat/types_ge_408.ml
+++ b/src/compat/types_ge_408.ml
@@ -1,0 +1,30 @@
+type module_type_407 =
+  | Mty_ident of Path.t
+  | Mty_signature of Types.signature
+  | Mty_functor of Ident.t * Types.module_type option * Types.module_type
+  | Mty_alias of unit * Path.t
+
+let migrate_module_type : Types.module_type -> module_type_407 = function
+  | Mty_ident p -> Mty_ident p
+  | Mty_signature s -> Mty_signature s
+  | Mty_functor (i, mto, mt) -> Mty_functor (i, mto, mt)
+  | Mty_alias p -> Mty_alias ((), p)
+
+type signature_item_407 =
+  | Sig_value of Ident.t * Types.value_description
+  | Sig_type of Ident.t * Types.type_declaration * Types.rec_status
+  | Sig_typext of Ident.t * Types.extension_constructor * Types.ext_status
+  | Sig_module of Ident.t * Types.module_declaration * Types.rec_status
+  | Sig_modtype of Ident.t * Types.modtype_declaration
+  | Sig_class of Ident.t * Types.class_declaration * Types.rec_status
+  | Sig_class_type of Ident.t * Types.class_type_declaration * Types.rec_status
+
+let migrate_signature_item : Types.signature_item -> signature_item_407 =
+  function
+  | Sig_value (id, vd, _) -> Sig_value (id, vd)
+  | Sig_type (id, td, r, _) -> Sig_type (id, td, r)
+  | Sig_typext (id, ec, es, _) -> Sig_typext (id, ec, es)
+  | Sig_module (id, _, md, rs, _) -> Sig_module (id, md, rs)
+  | Sig_modtype (id, td, _) -> Sig_modtype (id, td)
+  | Sig_class (id, cd, rs, _) -> Sig_class (id, cd, rs)
+  | Sig_class_type (id, ctd, rs, _) -> Sig_class_type (id, ctd, rs)

--- a/src/compat/types_lt_408.ml
+++ b/src/compat/types_lt_408.ml
@@ -1,0 +1,9 @@
+type module_type_407 = Types.module_type
+
+let migrate_module_type : Types.module_type -> module_type_407 =
+  fun x -> x
+
+type signature_item_407 = Types.signature_item
+
+let migrate_signature_item : Types.signature_item -> signature_item_407 =
+  fun x -> x

--- a/src/dune
+++ b/src/dune
@@ -3,7 +3,6 @@
  (kind ppx_rewriter)
  (preprocess (pps ppx_tools_versioned.metaquot_407))
  (libraries ppx_tools_versioned
-            ppx_tools_versioned.metaquot_407
             ocaml-migrate-parsetree))
 
 (rule

--- a/src/dune
+++ b/src/dune
@@ -5,3 +5,9 @@
  (libraries ppx_tools_versioned
             ppx_tools_versioned.metaquot_407
             ocaml-migrate-parsetree))
+
+(rule
+ (deps (glob_files compat/*.ml))
+ (targets compat.ml)
+ (action
+  (with-stdout-to %{targets} (run ./compat/gen.exe))))

--- a/src/ppx_import.ml
+++ b/src/ppx_import.ml
@@ -44,7 +44,7 @@ let lazy_env = lazy (
      modules. On the other hand, setting recursive_types more often
      than necessary does not seem harmful. *)
   Clflags.recursive_types := true;
-  Compmisc.init_path false;
+  Compat.init_path ();
   Compmisc.initial_env ()
 )
 
@@ -95,7 +95,7 @@ let try_find_module_type ~loc env lid =
   with Not_found -> None
 
 let rec try_open_module_type env module_type =
-  match module_type with
+  match Compat.migrate_module_type module_type with
   | Mty_signature sig_items -> Some sig_items
   | Mty_functor _ -> None
   | (Mty_ident path | Mty_alias (_, path) ) ->
@@ -132,7 +132,7 @@ let locate_sig ~loc env lid =
   let get_sub_module_type (lid, module_type) path_item =
     let sig_items = open_module_type ~loc env lid module_type in
     let rec loop sig_items =
-      match sig_items with
+      match (sig_items : Compat.signature_item_407 list) with
       | Sig_module (id, { md_type ; _ }, _) :: _
         when Ident.name id = path_item ->
         md_type
@@ -145,7 +145,7 @@ let locate_sig ~loc env lid =
         raise_errorf ~loc "[%%import]: cannot find the signature of %s in %s"
           path_item (string_of_lid lid)
     in
-    let sub_module_type = loop sig_items in
+    let sub_module_type = loop (List.map Compat.migrate_signature_item sig_items) in
     (Longident.Ldot (lid, path_item), sub_module_type)
   in
   let (_lid, sub_module_type) =
@@ -163,7 +163,8 @@ let try_get_tsig_item f ~loc:_ sig_items elem =
   loop sig_items
 
 let get_type_decl ~loc sig_items parent_lid elem =
-  let select_type elem = function
+  let select_type elem sigi =
+    match Compat.migrate_signature_item sigi with
     | Sig_type (id, type_decl, _) when Ident.name id = elem -> Some type_decl
     | _ -> None
   in
@@ -174,7 +175,8 @@ let get_type_decl ~loc sig_items parent_lid elem =
   | Some decl -> decl
 
 let get_modtype_decl ~loc sig_items parent_lid elem =
-  let select_modtype elem = function
+  let select_modtype elem sigi =
+    match Compat.migrate_signature_item sigi with
     | Sig_modtype (id, type_decl) when Ident.name id = elem -> Some type_decl
     | _ -> None
   in
@@ -382,14 +384,14 @@ let type_declaration ~tool_name mapper type_decl =
     end
   | _ -> default_mapper.type_declaration mapper type_decl
 
-let rec cut_tsig_block_of_rec_types accu tsig =
+let rec cut_tsig_block_of_rec_types accu (tsig : Compat.signature_item_407 list) =
   match tsig with
   | Sig_type (id, ttype_decl, Trec_next) :: rest ->
       cut_tsig_block_of_rec_types ((id, ttype_decl) :: accu) rest
   | _ ->
       (List.rev accu, tsig)
 
-let rec psig_of_tsig ~subst tsig =
+let rec psig_of_tsig ~subst (tsig : Compat.signature_item_407 list) =
   match tsig with
   | Sig_type (id, ttype_decl, rec_flag) :: rest ->
       let accu = [(id, ttype_decl)] in
@@ -455,7 +457,9 @@ let module_type ~tool_name mapper modtype_decl =
           match tmodtype_decl with
           | { mtd_type = Some (Mty_signature tsig) ; _} ->
             let subst = List.map (fun ({ txt ; _ }, typ) -> `Lid txt, typ) subst in
-            let psig  = psig_of_tsig ~subst tsig in
+            let psig =
+              psig_of_tsig ~subst (List.map Compat.migrate_signature_item tsig)
+            in
             { modtype_decl with pmty_desc = Pmty_signature psig }
           | { mtd_type = None ; _ } ->
             raise_errorf ~loc "Imported module is abstract"

--- a/src/ppx_import.ml
+++ b/src/ppx_import.ml
@@ -184,11 +184,7 @@ let get_modtype_decl ~loc sig_items parent_lid elem =
       elem (string_of_lid parent_lid)
   | Some decl -> decl
 
-let rec longident_of_path path =
-  match path with
-  | Path.Pident id -> Lident (Ident.name id)
-  | Path.Pdot (path, name, _) -> Ldot (longident_of_path path, name)
-  | Path.Papply (lhs, rhs) -> Lapply (longident_of_path lhs, longident_of_path rhs)
+let longident_of_path = Untypeast.lident_of_path
 
 let rec core_type_of_type_expr ~subst type_expr =
   match type_expr.desc with

--- a/src/ppx_import.ml
+++ b/src/ppx_import.ml
@@ -13,9 +13,9 @@ open Types
 
 module Tt = Ppx_types_migrate
 
-let raise_errorf ?sub ?if_highlight ?loc message =
+let raise_errorf ?sub ?loc message =
   message |> Printf.kprintf (fun str ->
-    let err = Location.error ?sub ?if_highlight ?loc str in
+    let err = Location.error ?sub ?loc str in
     raise (Location.Error err))
 
 let replace_loc loc =

--- a/src/ppx_types_migrate.ml
+++ b/src/ppx_types_migrate.ml
@@ -28,11 +28,8 @@ let copy_arg_label (l : At.arg_label) : Ab.arg_label =
   | At.Optional x -> Ab.Optional x
 
 (* Here we want to do a hack due to the large type *)
-let copy_attributes (l : Pt.attributes) : Pb.attributes =
+let copy_attributes (attrs : Pt.attributes) : Pb.attributes =
   (* Hack *)
-  let td = Pt.({ ptyp_desc = Ptyp_any
-               ; ptyp_loc = Location.none
-               ; ptyp_attributes = l
-               } ) in
-  let td = IMigrate.copy_core_type td in
-  td.ptyp_attributes
+  let td = Ast_helper.Typ.any ~attrs () in
+  let tb = IMigrate.copy_core_type td in
+  tb.ptyp_attributes


### PR DESCRIPTION
Hi!

This PR adds support to OCaml 4.08 (#41). There are several aspects to this:

- some helpers can be made compatible with more versions of the compiler "for free" by using features of `compiler-libs` (see the first commits)
- the main bit of work is being able to deconstruct `Types.module_type` and `Types.signature_item` from different versions of the compiler. To do so, I created a `Utypes` module that contains just what we need, and some shallow conversion functions are provided in a compat module that is selected by dune.

This is not perfect but I think it's a nice solution until OMP or a similar library supports `Types`.

Some additional remarks:
- I think that the first commits make sense to merge even if the rest is not
- 4.09 compatibility is fairly easy to add (part of the init code needs to be put in compat), but this either adds duplication (we'd need a compat file for <= 4.07, one for 4.08, and one for >= 4.09) or complexity (by having one compat module by versioned feature).

Let me know what you think.

Thanks