### PR TITLE
Remove a warning in OCaml 4.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,15 @@ env:
   - OCAML=4.07.1
   - OCAML=4.08.0
   - OCAML=4.08.1
-  - OCAML=4.09.0
+  - OCAML=4.09.1
   - OCAML=4.10.0
-# Wait until ocaml-base-compiler.4.09.1 arrives to opam-repository
-#  - OCAML=4.09.1
+  - OCAML=4.11.0+trunk
 
 script:
   - sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.6/opam-2.0.6-x86_64-linux -o /usr/bin/opam
   - sudo chmod 755 /usr/bin/opam
-  - opam init --disable-sandboxing -c $OCAML
-  - opam switch set $OCAML
+  - opam init --disable-sandboxing --bare
+  - opam switch create --repo=default,beta=git://github.com/ocaml/ocaml-beta-repository.git $OCAML
   - eval $(opam env)
   - opam pin add -n -k path ppx_import .
   - opam install --deps-only -d -t ppx_import

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+1.7.2
+-----
+
+  * Remove a warning in OCaml 4.11
+    #49
+    (Kate Deplaix)
+
 1.7.1
 -----
 

--- a/ppx_import.opam
+++ b/ppx_import.opam
@@ -12,7 +12,7 @@ dev-repo: "git+https://github.com/ocaml-ppx/ppx_import.git"
 tags: [ "syntax" ]
 
 depends: [
-  "ocaml"                   {              >= "4.04.2" & < "4.11" }
+  "ocaml"                   {              >= "4.04.2" & < "4.12" }
   "dune"                    {              >= "1.2.0"  }
   "ppxlib"                  {              >= "0.3.1"  }
   "ppx_tools_versioned"     {              >= "5.2.2"  }

--- a/ppx_import.opam
+++ b/ppx_import.opam
@@ -14,7 +14,6 @@ tags: [ "syntax" ]
 depends: [
   "ocaml"                   {              >= "4.04.2" & < "4.12" }
   "dune"                    {              >= "1.2.0"  }
-  "ppxlib"                  {              >= "0.3.1"  }
   "ppx_tools_versioned"     {              >= "5.2.2"  }
   "ocaml-migrate-parsetree" {              >= "1.2.0"  }
   "ounit"                   { with-test                }

--- a/src/ppx_import.ml
+++ b/src/ppx_import.ml
@@ -405,7 +405,7 @@ let rec psig_of_tsig ~subst (tsig : Compat.signature_item_407 list) =
           (Location.mknoloc (Ident.name id)) ttype_decl) in
       let psig_desc = Psig_type(rec_flag, block) in
       { psig_desc; psig_loc = Location.none } :: psig_of_tsig ~subst rest
-  | Sig_value (id, { val_type; val_kind; val_loc; val_attributes }) :: rest ->
+  | Sig_value (id, { val_type; val_kind; val_loc; val_attributes; _ }) :: rest ->
     let pval_prim =
       match val_kind with
       | Val_reg -> []


### PR DESCRIPTION
Currently ppx_import does not support OCaml 4.11. This PR fixes the issue