### PR TITLE
Upgrade from Ast_407 to Ast_411

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   - OCAML=4.08.1
   - OCAML=4.09.1
   - OCAML=4.10.0
-  - OCAML=4.11.0+trunk
+  - OCAML=4.11.1
 
 script:
   - sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.6/opam-2.0.6-x86_64-linux -o /usr/bin/opam

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+1.8.0
+-----
+
+  * Upgrade the internal AST from 4.07 to 4.11
+    #52
+    (Gabriel Scherer, review by Emilio J. Gallego Arias)
+
 1.7.2
 -----
 

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (public_name ppx_import)
  (kind ppx_rewriter)
- (preprocess (pps ppx_tools_versioned.metaquot_410))
+ (preprocess (pps ppx_tools_versioned.metaquot_411))
  (libraries ppx_tools_versioned
             ocaml-migrate-parsetree))
 

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (public_name ppx_import)
  (kind ppx_rewriter)
- (preprocess (pps ppx_tools_versioned.metaquot_409))
+ (preprocess (pps ppx_tools_versioned.metaquot_410))
  (libraries ppx_tools_versioned
             ocaml-migrate-parsetree))
 

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (public_name ppx_import)
  (kind ppx_rewriter)
- (preprocess (pps ppx_tools_versioned.metaquot_407))
+ (preprocess (pps ppx_tools_versioned.metaquot_408))
  (libraries ppx_tools_versioned
             ocaml-migrate-parsetree))
 

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (public_name ppx_import)
  (kind ppx_rewriter)
- (preprocess (pps ppx_tools_versioned.metaquot_408))
+ (preprocess (pps ppx_tools_versioned.metaquot_409))
  (libraries ppx_tools_versioned
             ocaml-migrate-parsetree))
 

--- a/src/ppx_import.ml
+++ b/src/ppx_import.ml
@@ -1,14 +1,14 @@
 (* Don't mask native Outcometree *)
 module Ot = Outcometree
 
-open Ppx_tools_409
+open Ppx_tools_410
 
 open Migrate_parsetree
-open Ast_409.Longident
-open Ast_409.Asttypes
-open Ast_409.Parsetree
-open Ast_409.Ast_mapper
-open Ast_409.Ast_helper
+open Ast_410.Longident
+open Ast_410.Asttypes
+open Ast_410.Parsetree
+open Ast_410.Ast_mapper
+open Ast_410.Ast_helper
 open Types
 
 module Tt = Ppx_types_migrate
@@ -485,7 +485,7 @@ let () =
   (* Position 0 is the default, ppx_import should run pretty early,
      thus using -10 *)
   Driver.register ~name:"ppx_import" ~args:[] ~position:(-10)
-    Versions.ocaml_409 (fun config _cookies ->
+    Versions.ocaml_410 (fun config _cookies ->
         let tool_name = config.tool_name in
         let type_declaration = type_declaration ~tool_name in
         let module_type = module_type ~tool_name in

--- a/src/ppx_import.ml
+++ b/src/ppx_import.ml
@@ -1,14 +1,14 @@
 (* Don't mask native Outcometree *)
 module Ot = Outcometree
 
-open Ppx_tools_410
+open Ppx_tools_411
 
 open Migrate_parsetree
-open Ast_410.Longident
-open Ast_410.Asttypes
-open Ast_410.Parsetree
-open Ast_410.Ast_mapper
-open Ast_410.Ast_helper
+open Ast_411.Longident
+open Ast_411.Asttypes
+open Ast_411.Parsetree
+open Ast_411.Ast_mapper
+open Ast_411.Ast_helper
 open Types
 
 module Tt = Ppx_types_migrate
@@ -485,7 +485,7 @@ let () =
   (* Position 0 is the default, ppx_import should run pretty early,
      thus using -10 *)
   Driver.register ~name:"ppx_import" ~args:[] ~position:(-10)
-    Versions.ocaml_410 (fun config _cookies ->
+    Versions.ocaml_411 (fun config _cookies ->
         let tool_name = config.tool_name in
         let type_declaration = type_declaration ~tool_name in
         let module_type = module_type ~tool_name in

--- a/src/ppx_import.ml
+++ b/src/ppx_import.ml
@@ -1,14 +1,14 @@
 (* Don't mask native Outcometree *)
 module Ot = Outcometree
 
-open Ppx_tools_408
+open Ppx_tools_409
 
 open Migrate_parsetree
-open Ast_408.Longident
-open Ast_408.Asttypes
-open Ast_408.Parsetree
-open Ast_408.Ast_mapper
-open Ast_408.Ast_helper
+open Ast_409.Longident
+open Ast_409.Asttypes
+open Ast_409.Parsetree
+open Ast_409.Ast_mapper
+open Ast_409.Ast_helper
 open Types
 
 module Tt = Ppx_types_migrate
@@ -485,7 +485,7 @@ let () =
   (* Position 0 is the default, ppx_import should run pretty early,
      thus using -10 *)
   Driver.register ~name:"ppx_import" ~args:[] ~position:(-10)
-    Versions.ocaml_408 (fun config _cookies ->
+    Versions.ocaml_409 (fun config _cookies ->
         let tool_name = config.tool_name in
         let type_declaration = type_declaration ~tool_name in
         let module_type = module_type ~tool_name in

--- a/src/ppx_import.ml
+++ b/src/ppx_import.ml
@@ -1,14 +1,14 @@
 (* Don't mask native Outcometree *)
 module Ot = Outcometree
 
-open Ppx_tools_407
+open Ppx_tools_408
 
 open Migrate_parsetree
-open Ast_407.Longident
-open Ast_407.Asttypes
-open Ast_407.Parsetree
-open Ast_407.Ast_mapper
-open Ast_407.Ast_helper
+open Ast_408.Longident
+open Ast_408.Asttypes
+open Ast_408.Parsetree
+open Ast_408.Ast_mapper
+open Ast_408.Ast_helper
 open Types
 
 module Tt = Ppx_types_migrate
@@ -224,11 +224,14 @@ let rec core_type_of_type_expr ~subst type_expr =
     let fields =
       row_fields |> List.map (fun (label, row_field) ->
         let label = Location.mknoloc label in
-        match row_field with
-        | Rpresent None -> Rtag (label, [], true, [])
-        | Rpresent (Some ttyp) ->
-          Rtag (label, [], false, [core_type_of_type_expr ~subst ttyp])
-        | _ -> assert false)
+        let desc = match row_field with
+          | Rpresent None -> Rtag (label, true, [])
+          | Rpresent (Some ttyp) ->
+             Rtag (label, false, [core_type_of_type_expr ~subst ttyp])
+          | _ -> assert false
+        in
+        {prf_desc = desc; prf_loc = !default_loc; prf_attributes = [];}
+      )
     in
     Typ.variant fields Closed None
   | _ ->
@@ -306,13 +309,21 @@ let subst_of_manifest { ptyp_attributes; ptyp_loc ; _ } =
   let rec subst_of_expr expr =
     match expr with
     | [%expr [%e? { pexp_desc = Pexp_ident ({ txt = src ; _ }) ; _ }] :=
-             [%e? { pexp_desc = Pexp_ident (dst); pexp_attributes; pexp_loc }]] ->
-      [`Lid src, { ptyp_loc = pexp_loc; ptyp_attributes = pexp_attributes;
-                   ptyp_desc = Ptyp_constr (dst, []) }]
+             [%e? { pexp_desc = Pexp_ident (dst); pexp_attributes; pexp_loc; pexp_loc_stack }]] ->
+      [`Lid src, {
+          ptyp_loc = pexp_loc;
+          ptyp_loc_stack = pexp_loc_stack;
+          ptyp_attributes = pexp_attributes;
+          ptyp_desc = Ptyp_constr (dst, []);
+      }]
     | [%expr [%e? { pexp_desc = Pexp_ident ({ txt = src ; _ }) ; _ }] :=
-             [%e? { pexp_desc = Pexp_ident (dst); pexp_attributes; pexp_loc }]; [%e? rest]] ->
-      (`Lid src, { ptyp_loc = pexp_loc; ptyp_attributes = pexp_attributes;
-                   ptyp_desc = Ptyp_constr (dst, []) }) :: subst_of_expr rest
+             [%e? { pexp_desc = Pexp_ident (dst); pexp_attributes; pexp_loc; pexp_loc_stack; }]; [%e? rest]] ->
+      (`Lid src, {
+         ptyp_loc = pexp_loc;
+         ptyp_loc_stack = pexp_loc_stack;
+         ptyp_attributes = pexp_attributes;
+         ptyp_desc = Ptyp_constr (dst, [])
+      }) :: subst_of_expr rest
     | { pexp_loc ; _ } ->
       raise_errorf ~loc:pexp_loc "Invalid [@with] syntax"
   in
@@ -474,7 +485,7 @@ let () =
   (* Position 0 is the default, ppx_import should run pretty early,
      thus using -10 *)
   Driver.register ~name:"ppx_import" ~args:[] ~position:(-10)
-    Versions.ocaml_407 (fun config _cookies ->
+    Versions.ocaml_408 (fun config _cookies ->
         let tool_name = config.tool_name in
         let type_declaration = type_declaration ~tool_name in
         let module_type = module_type ~tool_name in

--- a/src/ppx_types_migrate.ml
+++ b/src/ppx_types_migrate.ml
@@ -3,11 +3,11 @@ module Pt = Parsetree
 module Ot = Outcometree
 
 open Migrate_parsetree
-module Ab = Ast_410.Asttypes
-module Pb = Ast_410.Parsetree
-module Ob = Ast_410.Outcometree
+module Ab = Ast_411.Asttypes
+module Pb = Ast_411.Parsetree
+module Ob = Ast_411.Outcometree
 
-module IMigrate = Convert(Versions.OCaml_current)(Versions.OCaml_410)
+module IMigrate = Convert(Versions.OCaml_current)(Versions.OCaml_411)
 
 (* copy_mutable_flag / private_flag / arg_label are not exported by
    OMP so not worth the pain of the hack *)

--- a/src/ppx_types_migrate.ml
+++ b/src/ppx_types_migrate.ml
@@ -3,11 +3,11 @@ module Pt = Parsetree
 module Ot = Outcometree
 
 open Migrate_parsetree
-module Ab = Ast_407.Asttypes
-module Pb = Ast_407.Parsetree
-module Ob = Ast_407.Outcometree
+module Ab = Ast_408.Asttypes
+module Pb = Ast_408.Parsetree
+module Ob = Ast_408.Outcometree
 
-module IMigrate = Convert(Versions.OCaml_current)(Versions.OCaml_407)
+module IMigrate = Convert(Versions.OCaml_current)(Versions.OCaml_408)
 
 (* copy_mutable_flag / private_flag / arg_label are not exported by
    OMP so not worth the pain of the hack *)

--- a/src/ppx_types_migrate.ml
+++ b/src/ppx_types_migrate.ml
@@ -3,11 +3,11 @@ module Pt = Parsetree
 module Ot = Outcometree
 
 open Migrate_parsetree
-module Ab = Ast_408.Asttypes
-module Pb = Ast_408.Parsetree
-module Ob = Ast_408.Outcometree
+module Ab = Ast_409.Asttypes
+module Pb = Ast_409.Parsetree
+module Ob = Ast_409.Outcometree
 
-module IMigrate = Convert(Versions.OCaml_current)(Versions.OCaml_408)
+module IMigrate = Convert(Versions.OCaml_current)(Versions.OCaml_409)
 
 (* copy_mutable_flag / private_flag / arg_label are not exported by
    OMP so not worth the pain of the hack *)

--- a/src/ppx_types_migrate.ml
+++ b/src/ppx_types_migrate.ml
@@ -3,11 +3,11 @@ module Pt = Parsetree
 module Ot = Outcometree
 
 open Migrate_parsetree
-module Ab = Ast_409.Asttypes
-module Pb = Ast_409.Parsetree
-module Ob = Ast_409.Outcometree
+module Ab = Ast_410.Asttypes
+module Pb = Ast_410.Parsetree
+module Ob = Ast_410.Outcometree
 
-module IMigrate = Convert(Versions.OCaml_current)(Versions.OCaml_409)
+module IMigrate = Convert(Versions.OCaml_current)(Versions.OCaml_410)
 
 (* copy_mutable_flag / private_flag / arg_label are not exported by
    OMP so not worth the pain of the hack *)


### PR DESCRIPTION
Fixes #50.

I was a bit surprised by how easy the change was: I had a couple things to change from 407 to 408, and then all following updates were no-ops. (`cd src && sed -i "s/408/409/g" *.* dune`, and that's it) The testsuite still passes, and the example from #50 is now correctly parsed. 