### PR TITLE
[ci] [opam] Bump OCaml upper bound to 4.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   - OCAML=4.09.1
   - OCAML=4.10.0
   - OCAML=4.11.1
+  - OCAML=4.12.0
 
 script:
   - sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.6/opam-2.0.6-x86_64-linux -o /usr/bin/opam

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+unreleased
+-----
+
+  * update CI to test OCaml 4.12.0, no changes required
+    (#53, Emilio J. Gallego Arias)
+
+  * remove the OCaml upper bound in the opam file
+    (#53, Emilio J. Gallego Arias, kit-ty-kate)
+
 1.8.0
 -----
 

--- a/ppx_import.opam
+++ b/ppx_import.opam
@@ -12,7 +12,7 @@ dev-repo: "git+https://github.com/ocaml-ppx/ppx_import.git"
 tags: [ "syntax" ]
 
 depends: [
-  "ocaml"                   {              >= "4.04.2" & < "4.12" }
+  "ocaml"                   {              >= "4.04.2" }
   "dune"                    {              >= "1.2.0"  }
   "ppx_tools_versioned"     {              >= "5.4.0"  }
   "ocaml-migrate-parsetree" {              >= "1.7.0"  }


### PR DESCRIPTION
ppx_import seems to work in 4.12 without further changes.

We may want to update the AST at a later point.

A question is if we should do a new release for this change in the
Opam file, but IMHO it would be more practical just to update
opam-repos?

What do you think @gasche @kit-ty-kate ?