### PR TITLE
Add test case in interface file (.mli)

### DIFF
--- a/src_test/ppx_deriving/test_intf.ml
+++ b/src_test/ppx_deriving/test_intf.ml
@@ -1,0 +1,1 @@
+type a = [%import: Stuff.a]

--- a/src_test/ppx_deriving/test_intf.mli
+++ b/src_test/ppx_deriving/test_intf.mli
@@ -1,0 +1,1 @@
+type a = [%import: Stuff.a]

--- a/src_test/ppx_deriving/test_ppx_import.ml
+++ b/src_test/ppx_deriving/test_ppx_import.ml
@@ -19,6 +19,7 @@ module type S_rec = [%import: (module Stuff.S_rec)]
 let test_constr _ctxt =
   ignore [A1; A2 "a"];
   ignore (Stuff.A1 = A1);
+  ignore (Test_intf.A1 = A1);
   ignore {b1 = A1; b2 = "x"; b3 = Int64.zero};
   ignore (`A : c);
   ignore (Int64.zero : d);


### PR DESCRIPTION
This ensures that the PPX is registered for interfaces.