### PR TITLE
Ppxlib.0.26.0 compatibility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+unreleased
+-----
+
+  * Update ppxlib to 0.26.0 (#69, @pitag-ha)
+
 1.9.1
 -----
 

--- a/ppx_import.opam
+++ b/ppx_import.opam
@@ -11,12 +11,22 @@ dev-repo: "git+https://github.com/ocaml-ppx/ppx_import.git"
 tags: [ "syntax" ]
 
 depends: [
-  "ocaml"                   {              >= "4.05.0"  }
+  (
+  "ocaml"                   {>= "4.05.0" &  < "4.10.0"  }
   "dune"                    {              >= "1.11.0"  }
-  "ppxlib"                  {              >= "0.24.0"  & < "0.26" }
+  "ppxlib"                  {              >= "0.26.0"  }
   "ounit"                   { with-test                 }
   "ppx_deriving"            { with-test  & >= "4.2.1"   }
+  )
+  |
+  (
+  "ocaml"                   { >= "4.10.0"               }
   "ppx_sexp_conv"           { with-test  & >= "v0.13.0" }
+  "dune"                    {              >= "1.11.0"  }
+  "ppxlib"                  {              >= "0.26.0"  }
+  "ounit"                   { with-test                 }
+  "ppx_deriving"            { with-test  & >= "4.2.1"   }
+  )
 ]
 
 build:      [["dune" "build"   "-p" name "-j" jobs]

--- a/src/ppx_import.ml
+++ b/src/ppx_import.ml
@@ -288,6 +288,7 @@ let ptype_decl_of_ttype_decl ~manifest ~subst ptype_name
                  in
                  { pcd_name =
                      {txt = Ocaml_common.Ident.name cd.cd_id; loc = cd.cd_loc}
+                 ; pcd_vars = []
                  ; pcd_args = map_args cd.cd_args
                  ; pcd_res
                  ; pcd_loc = cd.cd_loc

--- a/src_test/ppx_deriving_sexp/dune
+++ b/src_test/ppx_deriving_sexp/dune
@@ -1,4 +1,6 @@
 (test
  (name test_ppx_deriving_sexp)
+ (enabled_if
+  (>= %{ocaml_version} "4.10.0"))
  (preprocess
   (staged_pps ppx_import ppx_sexp_conv)))


### PR DESCRIPTION
This is a patch PR to make the PPX compatible with ppxlib.0.26.0 which has bumped the AST to 4.14/5.00.