### PR TITLE
use V2 module to register transformation

### DIFF
--- a/src/ppx_import.ml
+++ b/src/ppx_import.ml
@@ -615,7 +615,7 @@ let module_declaration_rule =
   Ppxlib.Context_free.Rule.extension module_declaration_extension
 
 let () =
-  Ppxlib.Driver.register_transformation
+  Ppxlib.Driver.V2.register_transformation
     ~rules:
       [ type_declaration_rule
       ; module_declaration_rule


### PR DESCRIPTION
That's what is documented in the manual: https://ocaml-ppx.github.io/ppxlib/ppxlib/writing-ppxs.html#defining-a-transformation